### PR TITLE
Add support for STM32 MCU based boards to TFT library

### DIFF
--- a/src/utility/Adafruit_ST7735.h
+++ b/src/utility/Adafruit_ST7735.h
@@ -139,7 +139,8 @@ class Adafruit_ST7735 : public Adafruit_GFX {
 #ifdef SPI_HAS_TRANSACTION
   SPISettings spisettings;
 #endif
-#if defined(ARDUINO_ARCH_SAM) || defined(__ARDUINO_ARC__)
+#if defined(ARDUINO_ARCH_SAM) || defined(__ARDUINO_ARC__) || \
+    defined(ARDUINO_ARCH_STM32)
   volatile uint32_t *dataport, *clkport, *csport, *rsport;
   uint32_t  _cs, _rs, _rst, _sid, _sclk,
            datapinmask, clkpinmask, cspinmask, rspinmask,

--- a/src/utility/glcdfont.c
+++ b/src/utility/glcdfont.c
@@ -1,4 +1,5 @@
-#if !defined(ARDUINO_ARCH_SAM) && !defined(__ARDUINO_ARC__)
+#if !defined(ARDUINO_ARCH_SAM) && !defined(__ARDUINO_ARC__) && \
+    !defined(ARDUINO_ARCH_STM32)
 #include <avr/io.h>
 #endif
 #include <avr/pgmspace.h> 


### PR DESCRIPTION
Hi,

This PR add the support of the [Arduino_Core_STM32](https://github.com/stm32duino/Arduino_Core_STM32)  for  the  STM32 MCU based board.
[Arduino_Core_STM32](https://github.com/stm32duino/Arduino_Core_STM32) and related tools are provided as packages thanks the Arduino Boards manager, see the [wiki](https://github.com/stm32duino/wiki/wiki/Boards-Manager)

Thanks in advance.