### PR TITLE
Add software SPI constructor

### DIFF
--- a/src/TFT.cpp
+++ b/src/TFT.cpp
@@ -35,6 +35,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 TFT EsploraTFT(7, 0, 1);
 #endif
 
+TFT::TFT(uint8_t CS, uint8_t RS, uint8_t SID, uint8_t SCLK, uint8_t RST) 
+  : Adafruit_ST7735(CS, RS, SID, SCLK, RST)
+{
+  // as we already know the orientation (landscape, therefore rotated),
+  // set default width and height without need to call begin() first.
+  _width = ST7735_TFTHEIGHT;
+  _height = ST7735_TFTWIDTH;
+}
+
 TFT::TFT(uint8_t CS, uint8_t RS, uint8_t RST) 
   : Adafruit_ST7735(CS, RS, RST)
 {

--- a/src/TFT.h
+++ b/src/TFT.h
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// @author Enrico Gueli <enrico.gueli@gmail.com>
 class TFT : public Adafruit_ST7735 {
 public:
+  TFT(uint8_t CS, uint8_t RS, uint8_t SID, uint8_t SCLK, uint8_t RST);
   TFT(uint8_t CS, uint8_t RS, uint8_t RST);
 
   void begin();  


### PR DESCRIPTION
This constructor exists in the underlying Adafruit_ST7735 library and is [promised by the TFT library reference page](https://www.arduino.cc/en/Reference/TFTConstructor) but was not provided by the TFT library.

Untested beyond compiling because I don't own the hardware. But it was reported to work here:
http://forum.arduino.cc/index.php?topic=566665.msg3913388#msg3913388

If this change isn't desired then the reference page should be corrected.