### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/Arduino/TFTPong/TFTPong.ino
+++ b/examples/Arduino/TFTPong/TFTPong.ino
@@ -121,8 +121,8 @@ void moveBall() {
 
 // this function checks the position of the ball
 // to see if it intersects with the paddle
-boolean inPaddle(int x, int y, int rectX, int rectY, int rectWidth, int rectHeight) {
-  boolean result = false;
+bool inPaddle(int x, int y, int rectX, int rectY, int rectWidth, int rectHeight) {
+  bool result = false;
 
   if ((x >= rectX && x <= (rectX + rectWidth)) &&
       (y >= rectY && y <= (rectY + rectHeight))) {

--- a/examples/Esplora/EsploraTFTPong/EsploraTFTPong.ino
+++ b/examples/Esplora/EsploraTFTPong/EsploraTFTPong.ino
@@ -114,8 +114,8 @@ void moveBall() {
 
 // this function checks the position of the ball
 // to see if it intersects with the paddle
-boolean inPaddle(int x, int y, int rectX, int rectY, int rectWidth, int rectHeight) {
-  boolean result = false;
+bool inPaddle(int x, int y, int rectX, int rectY, int rectWidth, int rectHeight) {
+  bool result = false;
 
   if ((x >= rectX && x <= (rectX + rectWidth)) &&
       (y >= rectY && y <= (rectY + rectHeight))) {


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633