### PR TITLE
Add support for STM8 MCU based boards to TFT library 

### DIFF
--- a/src/TFT.cpp
+++ b/src/TFT.cpp
@@ -35,8 +35,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 TFT EsploraTFT(7, 0, 1);
 #endif
 
-TFT::TFT(uint8_t CS, uint8_t RS, uint8_t RST) 
-  : Adafruit_ST7735(CS, RS, RST)
+TFT::TFT(uint8_t cs, uint8_t rs, uint8_t rst)
+  : Adafruit_ST7735(cs, rs, rst)
 {
   // as we already know the orientation (landscape, therefore rotated),
   // set default width and height without need to call begin() first.

--- a/src/TFT.h
+++ b/src/TFT.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// @author Enrico Gueli <enrico.gueli@gmail.com>
 class TFT : public Adafruit_ST7735 {
 public:
-  TFT(uint8_t CS, uint8_t RS, uint8_t RST);
+  TFT(uint8_t cs, uint8_t rs, uint8_t rst);
 
   void begin();  
 };

--- a/src/utility/Adafruit_ST7735.cpp
+++ b/src/utility/Adafruit_ST7735.cpp
@@ -7,7 +7,7 @@
  
   Check out the links above for our tutorials and wiring diagrams
   These displays use SPI to communicate, 4 or 5 pins are required to
-  interface (RST is optional)
+  interface (rst is optional)
   Adafruit invests time and resources providing this open source code,
   please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
@@ -375,7 +375,7 @@ void Adafruit_ST7735::commonInit(const uint8_t *cmdList) {
     *dataport  &= ~datapinmask;
   }
 
-  // toggle RST low to reset; CS low so it'll listen to us
+  // toggle rst low to reset; cs low so it'll listen to us
   *csport &= ~cspinmask;
   if (_rst) {
     pinMode(_rst, OUTPUT);

--- a/src/utility/Adafruit_ST7735.h
+++ b/src/utility/Adafruit_ST7735.h
@@ -7,7 +7,7 @@
  
   Check out the links above for our tutorials and wiring diagrams
   These displays use SPI to communicate, 4 or 5 pins are required to
-  interface (RST is optional)
+  interface (rst is optional)
   Adafruit invests time and resources providing this open source code,
   please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
@@ -98,9 +98,9 @@ class Adafruit_ST7735 : public Adafruit_GFX {
 
  public:
 
-  Adafruit_ST7735(uint8_t CS, uint8_t RS, uint8_t SID, uint8_t SCLK,
-    uint8_t RST);
-  Adafruit_ST7735(uint8_t CS, uint8_t RS, uint8_t RST);
+  Adafruit_ST7735(uint8_t cs, uint8_t rs, uint8_t sid, uint8_t sclk,
+    uint8_t rst);
+  Adafruit_ST7735(uint8_t cs, uint8_t rs, uint8_t rst);
 
   void     initB(void),                             // for ST7735B displays
            initG(void),                             // for ILI9163C displays

--- a/src/utility/glcdfont.c
+++ b/src/utility/glcdfont.c
@@ -1,5 +1,5 @@
 #if !defined(ARDUINO_ARCH_SAM) && !defined(__ARDUINO_ARC__) && \
-    !defined(ARDUINO_ARCH_STM32)
+    !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_ARCH_STM8)
 #include <avr/io.h>
 #endif
 #include <avr/pgmspace.h> 


### PR DESCRIPTION
Hi,

This PR add the support of the [Arduino_Core_STM8](https://github.com/stm32duino/Arduino_Core_STM8)  for  the  STM8 MCU based board.
[Arduino_Core_STM8](https://github.com/stm32duino/Arduino_Core_STM8) and related tools are provided as packages thanks the Arduino Boards manager, see the [wiki](https://github.com/stm32duino/wiki/wiki/Boards-Manager)

Thanks in advance.