### PR TITLE
Porting st7735 TFT driver for Spresense

### DIFF
--- a/src/utility/Adafruit_ST7735.h
+++ b/src/utility/Adafruit_ST7735.h
@@ -4,7 +4,7 @@
   ----> http://www.adafruit.com/products/358
   as well as Adafruit raw 1.8" TFT display
   ----> http://www.adafruit.com/products/618
- 
+
   Check out the links above for our tutorials and wiring diagrams
   These displays use SPI to communicate, 4 or 5 pins are required to
   interface (RST is optional)
@@ -30,6 +30,11 @@
 #include <avr/pgmspace.h>
 
 // some flags for initR() :(
+
+#ifdef ARDUINO_spresense_ast
+#define SPI_HAS_TRANSACTION 1
+#endif
+
 #define INITR_GREENTAB 0x0
 #define INITR_REDTAB   0x1
 #define INITR_BLACKTAB   0x2
@@ -90,7 +95,7 @@
 #define	ST7735_GREEN   0x07E0
 #define ST7735_CYAN    0x07FF
 #define ST7735_MAGENTA 0xF81F
-#define ST7735_YELLOW  0xFFE0  
+#define ST7735_YELLOW  0xFFE0
 #define ST7735_WHITE   0xFFFF
 
 
@@ -116,7 +121,7 @@ class Adafruit_ST7735 : public Adafruit_GFX {
            setRotation(uint8_t r),
            invertDisplay(boolean i);
   uint16_t Color565(uint8_t r, uint8_t g, uint8_t b) { return newColor(r, g, b);}
-  
+
   /* These are not for current use, 8-bit protocol only!
   uint8_t  readdata(void),
            readcommand8(uint8_t);
@@ -150,7 +155,11 @@ class Adafruit_ST7735 : public Adafruit_GFX {
   uint8_t  _cs, _rs, _rst, _sid, _sclk,
            datapinmask, clkpinmask, cspinmask, rspinmask,
            colstart, rowstart; // some displays need this changed
- #endif   
+  #ifdef ARDUINO_spresense_ast
+         uint32_t _cs_addr;
+         uint32_t _rs_addr;
+  #endif
+ #endif
 };
 
 #endif

--- a/src/utility/glcdfont.c
+++ b/src/utility/glcdfont.c
@@ -1,5 +1,5 @@
 #if !defined(ARDUINO_ARCH_SAM) && !defined(__ARDUINO_ARC__) && \
-    !defined(ARDUINO_ARCH_STM32)
+    !defined(ARDUINO_ARCH_STM32) && !defined(ARDUINO_spresense_ast)
 #include <avr/io.h>
 #endif
 #include <avr/pgmspace.h> 


### PR DESCRIPTION
* Using macro for chip select HIGH/LOW commands
* Using macro for RS HIGH/LOW commands

Tested on a Spresense with a 1.8 128x160 ST7735 TFT display connected to a Spresense extension board both on 3.3V and 5V GPIO voltage.
