### PR TITLE
Add access to init functions from TFT.cpp

### DIFF
--- a/src/TFT.cpp
+++ b/src/TFT.cpp
@@ -58,3 +58,13 @@ void TFT::begin() {
   initG();
   setRotation(1);
 }
+
+void TFT::begin(uint8_t init_opt) {
+  if(init_opt == INIT_B) initB();
+  else if (init_opt == INIT_G) initG();
+  else if (init_opt == INITR_REDTAB) initR(INITR_REDTAB);
+  else if (init_opt == INITR_BLACKTAB) initR(INITR_BLACKTAB);
+  else if (init_opt == INITR_GREENTAB) initR(INITR_GREENTAB);
+
+  setRotation(1);
+}

--- a/src/utility/Adafruit_ST7735.h
+++ b/src/utility/Adafruit_ST7735.h
@@ -33,6 +33,8 @@
 #define INITR_GREENTAB 0x0
 #define INITR_REDTAB   0x1
 #define INITR_BLACKTAB   0x2
+#define INIT_B 0x3
+#define INIT_G 0x4
 
 #define ST7735_TFTWIDTH  128
 #define ST7735_TFTHEIGHT 160


### PR DESCRIPTION
My TFT display has its Red and Blue channels inverted.

There are several mentions of this issue online, specially on Adafruit related repos, and none offers a straight solution other than digging through their libraries and changing hard coded definitions.

This proposed change overloads the TFT.begin() method to offers the access to the different initialization functions found in `Adafruit_ST7735.cpp`.

To change from RGB to BGR:
```
TFT.begin(INITR_BLACKTAB);
```