### PR TITLE
Fix sketch compilation CI configuration for MKR Zero

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -58,6 +58,7 @@ jobs:
           - fqbn: arduino:samd:mkrzero
             platforms: |
               - name: arduino:samd
+            type: arduino
 
         # Make board type-specific customizations to the matrix jobs
         include:


### PR DESCRIPTION
The "Compile Examples" GitHub Actions workflow provides a basic "smoke test" on the project by compiling the appropriate
example sketches for a selection of supported boards on every push, pull request, and periodically.

Some of the examples are written specifically for the [Arduino Esplora](https://docs.arduino.cc/retired/boards/arduino-esplora), with the rest intended for any other supported
board. In order to avoid spurious compilation failures, the workflow is configured to compile the correct examples for
each board by assigning them a "type" attribute. This attribute was omitted for [the `arduino:samd:mkrzero` board](https://store.arduino.cc/products/arduino-mkr-zero-i2s-bus-sd-for-sound-music-digital-audio-data) (https://github.com/arduino-libraries/TFT/commit/475cce4dac9c997683aa341ab26b69389a22612e), which
resulted in no examples being compiled for it ([example](https://github.com/arduino-libraries/TFT/runs/4699516623?check_suite_focus=true)).

The correct "type" attribute is hereby assigned to that board and all the non-Esplora example sketches will now be
compiled for it.